### PR TITLE
Multiple events in addEventListener do not work

### DIFF
--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -118,7 +118,8 @@ var replaceDataAttr      = require('./helpers/replaceDataAttr');
         /**
          * Refresh plugin on window resize or orientation change
          */
-        window.addEventListener('resize orientationchange', _debounce(refresh, 50, true));
+        window.addEventListener('resize', _debounce(refresh, 50, true));
+        window.addEventListener('orientationchange', _debounce(refresh, 50, true));
 
         /**
          * Handle scroll event to animate elements on scroll


### PR DESCRIPTION
When I resized the window or switched the orientation the refresh did not occur.
Thats because you tried to bind two events in one window.addEventListener call which is not possible, so I splitted them into single calls.