### PR TITLE
add ‘mirror’ option

### DIFF
--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -38,6 +38,7 @@ let options = {
   duration: 400,
   disable: false,
   once: false,
+  mirror: false,
   startEvent: 'DOMContentLoaded'
 };
 
@@ -52,7 +53,7 @@ const refresh = function refresh(initialize = false) {
     // Extend elements objects in $aosElements with their positions
     $aosElements = prepare($aosElements, options);
     // Perform scroll event, to refresh view and show/hide elements
-    handleScroll($aosElements, options.once);
+    handleScroll($aosElements);
 
     return $aosElements;
   }

--- a/src/js/helpers/getInlineOption.js
+++ b/src/js/helpers/getInlineOption.js
@@ -1,0 +1,20 @@
+/**
+ * Get inline option with a fallback.
+ *
+ * @param  {Node} el [Dom element]
+ * @param  {String} key [Option key]
+ * @param  {String} def [Default (fallback) value]
+ * @return {Mixed} [Option set with inline attributes or fallback value if not set]
+ */
+
+const getInlineOption = function(el, key, def) {
+  const attr = el.node.getAttribute('data-aos-' + key);
+  if ( typeof attr !== 'undefined' && attr === 'true' ) {
+    return true;
+  } else if ( typeof attr !== 'undefined' && attr === 'false' ) {
+    return false;
+  }
+  return def;
+}
+
+export default getInlineOption;

--- a/src/js/helpers/handleScroll.js
+++ b/src/js/helpers/handleScroll.js
@@ -2,17 +2,16 @@
  * Set or remove aos-animate class
  * @param {node} el         element
  * @param {int}  top        scrolled distance
- * @param {void} once
  */
-const setState = function (el, top, once) {
-  const attrOnce = el.node.getAttribute('data-aos-once');
-
-  if (top > el.position) {
+const setState = function (el, top) {
+  if (top > el.position.out && !el.options.once && el.options.mirror) {
+    el.node.classList.remove('aos-animate');
+  }
+  else if (top > el.position.in) {
     el.node.classList.add('aos-animate');
-  } else if (typeof attrOnce !== 'undefined') {
-    if (attrOnce === 'false' || (!once && attrOnce !== 'true')) {
-      el.node.classList.remove('aos-animate');
-    }
+  }
+  else if (!el.options.once) {
+    el.node.classList.remove('aos-animate');
   }
 };
 
@@ -24,7 +23,7 @@ const setState = function (el, top, once) {
  * @param  {bool} once               plugin option
  * @return {void}
  */
-const handleScroll = function ($elements, once) {
+const handleScroll = function ($elements) {
   const scrollTop = window.pageYOffset;
   const windowHeight = window.innerHeight;
   /**
@@ -32,7 +31,7 @@ const handleScroll = function ($elements, once) {
    * and animate them on scroll
    */
   $elements.forEach((el, i) => {
-    setState(el, windowHeight + scrollTop, once);
+    setState(el, windowHeight + scrollTop);
   });
 };
 

--- a/src/js/helpers/prepare.js
+++ b/src/js/helpers/prepare.js
@@ -1,11 +1,22 @@
 /* Clearing variables */
 
 import calculateOffset from './calculateOffset';
+import getInlineOption from './getInlineOption';
 
 const prepare = function ($elements, options) {
   $elements.forEach((el, i) => {
+    const positionIn = calculateOffset(el.node, options.offset);
+    const positionOut = positionIn + window.innerHeight;
+
     el.node.classList.add('aos-init');
-    el.position = calculateOffset(el.node, options.offset);
+    el.position = {
+      in: positionIn,
+      out: positionOut
+    };
+    el.options = {
+      once: getInlineOption(el, 'once', options.once),
+      mirror: getInlineOption(el, 'mirror', options.mirror)
+    }
   });
 
   return $elements;


### PR DESCRIPTION
Added an option to remove the animation class when the element is scrolled past the viewport, basically mirroring the animation from when it enters the viewport. The option name `mirror` sounded good to me, but feel free to rename it if you find it confusing.

Can also be set on single elements with `data-aos-mirror` attribute, and is set to `false` in global defaults, so that the original functionality is unaffected.

More details on changes:
- added a utility function to parse inline attributes;
- moved the getAttribute logic to the 'prepare' function; it made sense to me as per-element options are set just once, when all elements are parsed.

Looking forward to hear from you. KUTGW.
