### PR TITLE
Adding autoprefixer support to webpack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/michalsnik/aos/issues"
   },
   "devDependencies": {
+    "autoprefixer": "^6.7.7",
     "babel-core": "^6.9.1",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-object-assign": "^6.8.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var autoprefixer = require('autoprefixer');
 
 module.exports = {
   entry: './src/js/aos.js',
@@ -23,9 +24,14 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract("style-loader", "css-loader?sourceMap!sass-loader")
+        loader: ExtractTextPlugin.extract("style-loader", "css-loader?sourceMap!sass-loader!postcss-loader")
       }
     ]
+  },
+  postcss: function (webpack) {
+    return [
+      autoprefixer
+    ];
   },
   plugins: [
     new ExtractTextPlugin('aos.css'),


### PR DESCRIPTION
This is to allow support for browser prefix on specific devices where animations are not working (iOS and Android).