### PR TITLE
Update styles.css

### DIFF
--- a/demo/css/styles.css
+++ b/demo/css/styles.css
@@ -8,10 +8,18 @@ body {
   box-sizing: border-box;
 }
 
-.aos-all {
-  width: 1000px;
-  max-width: 98%;
-  margin: 10vh auto 0 auto;
+/* MAKE SURE THE WRAPPER DIV IS ALWAYS 100% IN WIDTH */
+.aos-all {  
+  max-width: 100% !important;
+  width: 100% !important;
+  width: 100vw !important;
+  /* overflow is hidden since 
+  animations are outside the wrapper 
+  creating horizontal scrolling */
+  overflow: hidden;
+  /* margin is not mandatory if the wrapper
+  is neede with margins */
+  margin: 0;    
 }
 
 .aos-item {


### PR DESCRIPTION
Fix the horizontal scrolling bar appearing on mobile devices due to the fact that the animations overflow the wrapping container.

/* MAKE SURE THE WRAPPER DIV IS ALWAYS 100% IN WIDTH */
.aos-all {  
  max-width: 100% !important;
  width: 100% !important;
  width: 100vw !important; 
   /* overflow is hidden since animations are outside the wrapper creating horizontal scrolling */
  overflow: hidden;  
  /* margin is not mandatory if the wrapper is needed with certain margins */
  margin: 0;   
}