### PR TITLE
Elements hidden in firefox bugfix

### DIFF
--- a/src/sass/_animations.scss
+++ b/src/sass/_animations.scss
@@ -17,7 +17,7 @@ $aos-distance: 100px !default;
 
   &.aos-animate {
     opacity: 1;
-    transform: translate(0, 0);
+    transform: translate(0px, 0);
   }
 }
 
@@ -68,7 +68,7 @@ $aos-distance: 100px !default;
 
   &.aos-animate {
     opacity: 1;
-    transform: translate(0, 0) scale(1);
+    transform: translate(0px, 0) scale(1);
   }
 }
 
@@ -123,7 +123,7 @@ $aos-distance: 100px !default;
   transition-property: transform;
 
   &.aos-animate {
-    transform: translate(0, 0);
+    transform: translate(0px, 0);
   }
 }
 


### PR DESCRIPTION
Missing px when translate(0) can in some combinations hide the element after animation in firefox browser.
Adding px --> translate(0px) fixes the hidden-element bug.