### PR TITLE
Add option to disable MutationObserver

### DIFF
--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -38,7 +38,8 @@ let options = {
   duration: 400,
   disable: false,
   once: false,
-  startEvent: 'DOMContentLoaded'
+  startEvent: 'DOMContentLoaded',
+  disableMutationObserver: false
 };
 
 /**
@@ -160,7 +161,9 @@ const init = function init(settings) {
    * If something is loaded by AJAX
    * it'll refresh plugin automatically
    */
-  observe('[data-aos]', refreshHard);
+  if (!options.disableMutationObserver) {
+    observe('[data-aos]', refreshHard);
+  }
 
   return $aosElements;
 };


### PR DESCRIPTION
MutationObserver is awesome, and it works great in AOS — almost always.

I recently ran into an issue with [lazysizes](https://github.com/aFarkas/lazysizes) where the MutationObserver in AOS would `refreshHard` a ton of times on page load and as you scroll because the lazyloaded images were updating attributes and classes.

- This is only an issue when animating a parent `div` while the child `img` is being lazyloaded
- In Chrome, this caused anywhere from a 2-4s delay in all scripts running because the browser is overloaded (depending on the number of elements updating that is)
- You must manually `AOS.resetHard()` when running ajax or other conditional content

This took me forever to narrow down so thought I'd put it up as a PR. No pressure to accept it, but it's a lot easier to have this init option than sifting through the minified file that I had to do.