### PR TITLE
Support for custom scrollable element

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -10,12 +10,12 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
     <style>
-    .aos-all {
+    /* .aos-all {
       position: fixed;
       width: 100%;
       height: 100%;
       overflow: scroll;
-    }
+    } */
     </style>
   </head>
   <body>
@@ -54,7 +54,7 @@
 
         AOS.init({
           mirror: true,
-          targetSelector: ".aos-all"
+          // targetSelector: ".aos-all"
         });
 
         document.addEventListener('aos:in', ({ detail }) => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,14 @@
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
+    <style>
+    .aos-all {
+      position: fixed;
+      width: 100%;
+      height: 100%;
+      overflow: scroll;
+    }
+    </style>
   </head>
   <body>
     <div class="js-scroll-counter scroll-counter"></div>
@@ -45,7 +53,8 @@
         const scrollCounter = document.querySelector('.js-scroll-counter');
 
         AOS.init({
-          mirror: true
+          mirror: true,
+          targetSelector: ".aos-all"
         });
 
         document.addEventListener('aos:in', ({ detail }) => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,14 +9,6 @@
     <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
-    <style>
-    /* .aos-all {
-      position: fixed;
-      width: 100%;
-      height: 100%;
-      overflow: scroll;
-    } */
-    </style>
   </head>
   <body>
     <div class="js-scroll-counter scroll-counter"></div>
@@ -53,8 +45,7 @@
         const scrollCounter = document.querySelector('.js-scroll-counter');
 
         AOS.init({
-          mirror: true,
-          // targetSelector: ".aos-all"
+          mirror: true
         });
 
         document.addEventListener('aos:in', ({ detail }) => {

--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -41,7 +41,8 @@ let options = {
   startEvent: 'DOMContentLoaded',
   animatedClassName: 'aos-animate',
   initClassName: 'aos-init',
-  useClassNames: false
+  useClassNames: false,
+  targetSelector: 'window'
 };
 
 /**
@@ -55,7 +56,7 @@ const refresh = function refresh(initialize = false) {
     // Extend elements objects in $aosElements with their positions
     $aosElements = prepare($aosElements, options);
     // Perform scroll event, to refresh view and show/hide elements
-    handleScroll($aosElements);
+    handleScroll(0, $aosElements);
 
     return $aosElements;
   }
@@ -171,12 +172,21 @@ const init = function init(settings) {
   /**
    * Handle scroll event to animate elements on scroll
    */
-  window.addEventListener(
-    'scroll',
-    throttle(() => {
-      handleScroll($aosElements, options.once);
-    }, 99)
-  );
+  if (options.targetSelector === 'window') {
+    window.addEventListener(
+      'scroll',
+      throttle(() => {
+        handleScroll(window.pageYOffset, $aosElements, options.once);
+      }, 99)
+    );
+  } else {
+    document.querySelector(options.targetSelector).addEventListener(
+      'scroll',
+      throttle(e => {
+        handleScroll(e.target.scrollTop, $aosElements, options.once);
+      }, 99)
+    );
+  }
 
   /**
    * Observe [aos] elements

--- a/src/js/helpers/handleScroll.js
+++ b/src/js/helpers/handleScroll.js
@@ -67,10 +67,13 @@ const applyClasses = (el, top) => {
 /**
  * Scroll logic - add or remove 'aos-animate' class on scroll
  *
+ * @param  {int}   top               distance to scroll
  * @param  {array} $elements         array of elements nodes
  * @return {void}
  */
-const handleScroll = $elements =>
-  $elements.forEach((el, i) => applyClasses(el, window.pageYOffset));
+const handleScroll = (top, $elements) =>
+  $elements.forEach((el, i) => {
+    applyClasses(el, top);
+  });
 
 export default handleScroll;


### PR DESCRIPTION
Hello,

As asked in #223, I added support for selecting custom scrollable element.
Now you can specify a selector of the element that is scrolled instead of window (i.e. fixed div with content overflow)

You provide targetSelector when initing AOS

```javascript
AOS.init({
  targetSelector: ".someClass",
});
```




