### PR TITLE
move browser related object from global to function level

### DIFF
--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -24,10 +24,6 @@ import elements from './helpers/elements';
 let $aosElements = [];
 let initialized = false;
 
-// Detect not supported browsers (<=IE9)
-// http://browserhacks.com/#hack-e71d8692f65334173fee715c222cb805
-const browserNotSupported = document.all && !window.atob;
-
 /**
  * Default options
  */
@@ -109,6 +105,10 @@ const init = function init(settings) {
 
   // Create initial array with elements -> to be fullfilled later with prepare()
   $aosElements = elements();
+
+  // Detect not supported browsers (<=IE9)
+  // http://browserhacks.com/#hack-e71d8692f65334173fee715c222cb805
+  const browserNotSupported = document.all && !window.atob;
 
   /**
    * Don't init plugin if option `disable` is set

--- a/src/js/libs/observer.js
+++ b/src/js/libs/observer.js
@@ -1,12 +1,12 @@
-const doc = window.document;
-const MutationObserver =
+let callback = () => {};
+
+function ready(selector, fn) {
+  const doc = window.document;
+  const MutationObserver =
   window.MutationObserver ||
   window.WebKitMutationObserver ||
   window.MozMutationObserver;
 
-let callback = () => {};
-
-function ready(selector, fn) {
   const observer = new MutationObserver(check);
   callback = fn;
 


### PR DESCRIPTION
## issue
The server side rendering fails for us due to the top level presence of browser specific object like `window` / `document`. These statements are evaluated as long as we import `aos`. As a result, we get errors like `window is not defined`. 

## Fix
Move them to function level so that we can control whether to call them depend on specific runtime(browser/server). 
This change should have no functional impact as we just move the variables from global to the function that use them.

