### PR TITLE
Implemented a new method for releasing event listeners from DOM

### DIFF
--- a/cypress/integration/aos_spec.js
+++ b/cypress/integration/aos_spec.js
@@ -11,6 +11,13 @@ describe('AOS', function() {
       .should('exist');
   });
 
+  it('Should have destroy method', function() {
+    cy
+      .window()
+      .its('AOS.destroy')
+      .should('exist');
+  });
+
   it('Should have init method', function() {
     cy
       .window()

--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -56,9 +56,7 @@ const initializeScroll = function initializeScroll() {
    */
   window.addEventListener(
     'scroll',
-    throttle(() => {
-      handleScroll($aosElements, options.once);
-    }, 99)
+    scrollEvent
   );
 
   return $aosElements;
@@ -170,13 +168,9 @@ const init = function init(settings) {
    */
   if (['DOMContentLoaded', 'load'].indexOf(options.startEvent) === -1) {
     // Listen to options.startEvent and initialize AOS
-    document.addEventListener(options.startEvent, function() {
-      refresh(true);
-    });
+    document.addEventListener(options.startEvent, loadEvent);
   } else {
-    window.addEventListener('load', function() {
-      refresh(true);
-    });
+    window.addEventListener('load', loadEvent);
   }
 
   if (
@@ -184,16 +178,50 @@ const init = function init(settings) {
     ['complete', 'interactive'].indexOf(document.readyState) > -1
   ) {
     // Initialize AOS if default startEvent was already fired
-    refresh(true);
+    loadEvent();
   }
 
   /**
    * Refresh plugin on window resize or orientation change
    */
-  window.addEventListener('resize', debounce(refresh, 50, true));
-  window.addEventListener('orientationchange', debounce(refresh, 50, true));
+  window.addEventListener('resize', orientationChangeEvent);
+  window.addEventListener('orientationchange', orientationChangeEvent);
 
   return $aosElements;
+};
+
+/*
+ * Remove event listeners from DOM
+ */
+const destroy = () => {
+  if (['DOMContentLoaded', 'load'].indexOf(options.startEvent) === -1) {
+    document.removeEventListener(options.startEvent, loadEvent);
+  } else {
+    window.removeEventListener('load', loadEvent);
+  }
+
+  window.removeEventListener('resize', orientationChangeEvent);
+  window.removeEventListener('orientationchange', orientationChangeEvent);
+  window.removeEventListener('scroll', scrollEvent);
+};
+
+/*
+ * Event listener for resize and orientation change
+ */
+const orientationChangeEvent = debounce(refresh, 50, true);
+
+/*
+ * Event listener for window scroll
+ */
+const scrollEvent = throttle(() => {
+  handleScroll($aosElements, options.once);
+}, 99);
+
+/*
+ * Event listener for document load
+ */
+const loadEvent = () => {
+  refresh(true);
 };
 
 /**
@@ -201,6 +229,7 @@ const init = function init(settings) {
  */
 
 export default {
+  destroy,
   init,
   refresh,
   refreshHard


### PR DESCRIPTION
## Related Issue
Issue #360

## Your solution
In this PR:
- I have separated methods from any `addEventListener` to be able to release it
- Created a new method called `destroy` and exposed it at `export`
- Created a test to check if this new method is defined

## How Has This Been Tested?
- By running `npm run test`
- Creating AOS and destroying it
    - Also checked `getEventListeners(window)` and `getEventListeners(document)` to see remaining listeners
