### PR TITLE
Add "container" setting, to allow attaching AOS to any scrollable element

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ AOS.init();
 // below listed default settings
 AOS.init({
   // Global settings
+  container: window, // AOS Container, accepts CSS Selector (e.g. ".my-awesome-container") or HTMLElement
   disable: false, // accepts following values: 'phone', 'tablet', 'mobile', boolean, expression or function
   startEvent: 'DOMContentLoaded', // name of the event dispatched on the document, that AOS should initialize on
   initClassName: 'aos-init', // class applied after initialization
@@ -86,7 +87,7 @@ AOS.init({
   easing: 'ease', // default easing for AOS animations
   once: false, // whether animation should happen only once - while scrolling down
   mirror: false, // whether elements should animate out while scrolling past them
-  anchorPlacement: 'top-bottom', // defines which position of the element regarding to window should trigger the animation
+  anchorPlacement: 'top-bottom', // defines which position of the element regarding to window/container should trigger the animation
 });
 ```
 

--- a/cypress/integration/settings_container.js
+++ b/cypress/integration/settings_container.js
@@ -1,0 +1,113 @@
+describe('setting: container', function() {
+  context('HTMLElement as container', function() {
+    before(() => {
+      cy.visit('/container.html');
+    });
+
+    it('Should initialize with HTMLElement', function() {
+      cy.document().then(document => {
+        const el = document.querySelector('.aos-all');
+        cy.initAOS({
+          container: el
+        });
+      });
+      cy.get('.aos-animate').should('have.length', 6);
+    });
+
+    it('Should animate next 3 items on scroll', function() {
+      cy.get('.aos-all').scrollTo(0, 100);
+      cy.get('.aos-animate').should('have.length', 9);
+    });
+  });
+
+  context('CSS Selector as container', function() {
+    before(() => {
+      cy.visit('/container.html');
+      cy.initAOS({
+        container: '.aos-all',
+        mirror: true
+      });
+    });
+
+    it('Should initialize with 6 items', function() {
+      cy.get('.aos-animate').should('have.length', 6);
+    });
+
+    it('Should animate next 3 items on scroll', function() {
+      cy.get('.aos-all').scrollTo(0, 100);
+      cy.get('.aos-animate').should('have.length', 9);
+    });
+  });
+
+  context('Should respect other properties', function() {
+    before(() => {
+      cy.visit('/container.html');
+      cy.initAOS({
+        container: '.aos-all',
+        mirror: true
+      });
+    });
+
+    it('Should respect: offset', function() {
+      cy.get('.aos-all').scrollTo(0, 435);
+      cy.get('.aos-animate').should('have.length', 8);
+
+      cy.get('.aos-all').scrollTo(0, 730);
+      cy.get('.aos-animate').should('have.length', 9);
+    });
+
+    it('Should respect: once', function() {
+      cy.get('.aos-all').scrollTo(0, 435);
+      cy.get('.aos-animate').should('have.length', 11);
+    });
+  });
+
+  context('Should respect: anchor', function() {
+    before(() => {
+      cy.visit('/container-anchor.html');
+      cy.initAOS({
+        container: '.aos-anchors'
+      });
+    });
+
+    it('Should properly animate elements according to anchor positions', () => {
+      cy.get('.aos-animate').should('have.length', 0);
+
+      cy.get('.aos-anchors').scrollTo(0, 50);
+      cy.get('.aos-animate').should('have.length', 1);
+      cy.get('[data-id="1"]').should('have.class', 'aos-animate');
+
+      cy.get('.aos-anchors').scrollTo(0, 550);
+      cy.get('.aos-animate').should('have.length', 2);
+      cy.get('[data-id="2"]').should('have.class', 'aos-animate');
+
+      cy.get('.aos-anchors').scrollTo(0, 810);
+      cy.get('.aos-animate').should('have.length', 3);
+      cy.get('[data-id="4"]').should('have.class', 'aos-animate');
+
+      cy.get('.aos-anchors').scrollTo(0, 1050);
+      cy.get('.aos-animate').should('have.length', 4);
+      cy.get('[data-id="3"]').should('have.class', 'aos-animate');
+
+      cy.get('.aos-anchors').scrollTo(0, 1320);
+      cy.get('.aos-animate').should('have.length', 5);
+      cy.get('[data-id="5"]').should('have.class', 'aos-animate');
+
+      cy.get('.aos-anchors').scrollTo(0, 1580);
+      cy.get('.aos-animate').should('have.length', 6);
+      cy.get('[data-id="7"]').should('have.class', 'aos-animate');
+
+      cy.get('.aos-anchors').scrollTo(0, 1810);
+      cy.get('.aos-animate').should('have.length', 7);
+      cy.get('[data-id="6"]').should('have.class', 'aos-animate');
+
+      cy.get('.aos-anchors').scrollTo(0, 2080);
+      cy.get('.aos-animate').should('have.length', 8);
+      cy.get('[data-id="8"]').should('have.class', 'aos-animate');
+
+      cy.get('.aos-anchors').scrollTo(0, 2570);
+      cy.get('.aos-animate').should('have.length', 9);
+      cy.get('[data-id="9"]').should('have.class', 'aos-animate');
+    });
+  });
+});

--- a/demo/container-anchor.html
+++ b/demo/container-anchor.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>AOS - Animate on scroll library</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="dist/aos.css" />
+    <style>
+      .aos-anchors__lines {
+        top: 50px;
+        height: 585px;
+      }
+      .aos-anchors {
+        position: fixed;
+        top: 0;
+        left: calc(50% - 200px);
+        height: 600px;
+        margin: 50px 0;
+        overflow: scroll;
+      }
+    </style>
+    <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="aos-anchors__lines"></div>
+    <div class="aos-anchors">
+      <div class="aos-anchors__sidebar">
+        <div data-id="1" data-aos="fade-up" data-aos-anchor="[data-anchor-id='1']" data-aos-anchor-placement="top-top">
+          Anchor: 1
+        </div>
+        <div data-id="2" data-aos="fade-up" data-aos-anchor="[data-anchor-id='2']" data-aos-anchor-placement="center-top">
+          Anchor: 2
+        </div>
+        <div data-id="3" data-aos="fade-up" data-aos-anchor="[data-anchor-id='3']" data-aos-anchor-placement="bottom-top">
+          Anchor: 3
+        </div>
+        <div data-id="4" data-aos="fade-up" data-aos-anchor="[data-anchor-id='4']" data-aos-anchor-placement="top-center">
+          Anchor: 4
+        </div>
+        <div data-id="5" data-aos="fade-up" data-aos-anchor="[data-anchor-id='5']" data-aos-anchor-placement="center-center">
+          Anchor: 5
+        </div>
+        <div data-id="6" data-aos="fade-up" data-aos-anchor="[data-anchor-id='6']" data-aos-anchor-placement="bottom-center">
+          Anchor: 6
+        </div>
+        <div data-id="7" data-aos="fade-up" data-aos-anchor="[data-anchor-id='7']" data-aos-anchor-placement="top-bottom">
+          Anchor: 7
+        </div>
+        <div data-id="8" data-aos="fade-up" data-aos-anchor="[data-anchor-id='8']" data-aos-anchor-placement="center-bottom">
+          Anchor: 8
+        </div>
+        <div data-id="9" data-aos="fade-up" data-aos-anchor="[data-anchor-id='9']" data-aos-anchor-placement="bottom-bottom">
+          Anchor: 9
+        </div>
+      </div>
+      <div class="aos-anchors__content">
+        <div data-anchor-id="1" data-placement="top-top"></div>
+        <div data-anchor-id="2" data-placement="center-top"></div>
+        <div data-anchor-id="3" data-placement="bottom-top"></div>
+        <div data-anchor-id="4" data-placement="top-center"></div>
+        <div data-anchor-id="5" data-placement="center-center"></div>
+        <div data-anchor-id="6" data-placement="bottom-center"></div>
+        <div data-anchor-id="7" data-placement="top-bottom"></div>
+        <div data-anchor-id="8" data-placement="center-bottom"></div>
+        <div data-anchor-id="9" data-placement="bottom-bottom"></div>
+      </div>
+    </div>
+
+    <script src="dist/aos.js"></script>
+    <script>
+      if (!window.Cypress) AOS.init({
+        container: '.aos-anchors',
+      });
+    </script>
+  </body>
+</html>

--- a/demo/container.html
+++ b/demo/container.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>AOS - Animate on scroll library</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="dist/aos.css" />
+    <style>
+      .aos-all {
+        position: fixed;
+        width: 100%;
+        height: 100%;
+        overflow: scroll;
+      }
+    </style>
+    <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="aos-all">
+      <div data-id="1" class="aos-item" data-aos="fade-up"></div>
+      <div data-id="2" class="aos-item" data-aos="fade-down"></div>
+      <div data-id="3" class="aos-item" data-aos="zoom-out-down"></div>
+      <div data-id="4" class="aos-item" data-aos="flip-down"></div>
+      <div data-id="5" class="aos-item" data-aos="flip-up"></div>
+      <div data-id="6" class="aos-item" data-aos="fade-down"></div>
+      <div data-id="7" class="aos-item" data-aos="fade-in"></div>
+      <div data-id="8" class="aos-item" data-aos="fade-down"></div>
+      <div data-id="9" class="aos-item" data-aos="fade-in"></div>
+      <div data-id="10" class="aos-item" data-aos="fade-down" data-aos-id="super-duper"></div>
+      <div data-id="11" class="aos-item" data-aos="fade-up" data-aos-offset="400"></div>
+      <div data-id="12" class="aos-item" data-aos="fade-down"></div>
+      <div data-id="13" class="aos-item" data-aos="fade-in" data-aos-once="true"></div>
+      <div data-id="14" class="aos-item" data-aos="fade-up" data-aos-once="true"></div>
+      <div data-id="15" class="aos-item" data-aos="fade-in" data-aos-once="true"></div>
+      <div data-id="16" class="aos-item" data-aos="fade-up"></div>
+      <div data-id="17" class="aos-item" data-aos="fade-down"></div>
+      <div data-id="18" class="aos-item" data-aos="fade-up"></div>
+      <div data-id="19" class="aos-item" data-aos="zoom-out"></div>
+      <div data-id="20" class="aos-item" data-aos="fade-up"></div>
+      <div data-id="21" class="aos-item" data-aos="zoom-out"></div>
+      <div data-id="22" class="aos-item" data-aos="fade-in"></div>
+      <div data-id="23" class="aos-item" data-aos="zoom-out-up"></div>
+      <div data-id="24" class="aos-item" data-aos="zoom-out-down"></div>
+    </div>
+
+    <script src="dist/aos.js"></script>
+    <script>
+      if (!window.Cypress) {
+        AOS.init({
+          mirror: true,
+          container: ".aos-all"
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -53,7 +53,7 @@ const initializeScroll = function initializeScroll() {
   let container =
     options.container == 'window'
       ? window
-      : document.querySelector(options.container);
+      : document.querySelector(options.container) || window;
   // Perform scroll event, to refresh view and show/hide elements
   handleScroll($aosElements, container);
 

--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -16,6 +16,7 @@ import detect from './helpers/detector';
 import handleScroll from './helpers/handleScroll';
 import prepare from './helpers/prepare';
 import elements from './helpers/elements';
+import validContainer from './helpers/container';
 
 /**
  * Private variables
@@ -39,7 +40,7 @@ let options = {
   animatedClassName: 'aos-animate',
   initClassName: 'aos-init',
   useClassNames: false,
-  container: 'window'
+  container: window
 };
 
 // Detect not supported browsers (<=IE9)
@@ -50,10 +51,7 @@ const initializeScroll = function initializeScroll() {
   // Extend elements objects in $aosElements with their positions
   $aosElements = prepare($aosElements, options);
   // Define container element
-  let container =
-    options.container == 'window'
-      ? window
-      : document.querySelector(options.container) || window;
+  const container = validContainer(options.container);
   // Perform scroll event, to refresh view and show/hide elements
   handleScroll($aosElements, container);
 

--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -38,7 +38,8 @@ let options = {
   startEvent: 'DOMContentLoaded',
   animatedClassName: 'aos-animate',
   initClassName: 'aos-init',
-  useClassNames: false
+  useClassNames: false,
+  container: 'window'
 };
 
 // Detect not supported browsers (<=IE9)
@@ -48,16 +49,21 @@ const isBrowserNotSupported = () => document.all && !window.atob;
 const initializeScroll = function initializeScroll() {
   // Extend elements objects in $aosElements with their positions
   $aosElements = prepare($aosElements, options);
+  // Define container element
+  let container =
+    options.container == 'window'
+      ? window
+      : document.querySelector(options.container);
   // Perform scroll event, to refresh view and show/hide elements
-  handleScroll($aosElements);
+  handleScroll($aosElements, container);
 
   /**
    * Handle scroll event to animate elements on scroll
    */
-  window.addEventListener(
+  container.addEventListener(
     'scroll',
     throttle(() => {
-      handleScroll($aosElements, options.once);
+      handleScroll($aosElements, container);
     }, 99)
   );
 

--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -16,7 +16,7 @@ import detect from './helpers/detector';
 import handleScroll from './helpers/handleScroll';
 import prepare from './helpers/prepare';
 import elements from './helpers/elements';
-import validContainer from './helpers/container';
+import { resolveContainer } from './helpers/container';
 
 /**
  * Private variables
@@ -48,10 +48,12 @@ let options = {
 const isBrowserNotSupported = () => document.all && !window.atob;
 
 const initializeScroll = function initializeScroll() {
-  // Extend elements objects in $aosElements with their positions
-  $aosElements = prepare($aosElements, options);
   // Define container element
-  const container = validContainer(options.container);
+  const container = resolveContainer(options.container);
+  if (!container)
+    throw `AOS - cannot find the container element. The container option must be an HTMLElement or a CSS Selector.`;
+  // Extend elements objects in $aosElements with their positions
+  $aosElements = prepare($aosElements, options, container);
   // Perform scroll event, to refresh view and show/hide elements
   handleScroll($aosElements, container);
 

--- a/src/js/helpers/container.js
+++ b/src/js/helpers/container.js
@@ -1,11 +1,30 @@
 /**
- * Return provided container if valid, otherwise throw an error
+ * Returns valid container, or null
+ *
+ * @param  {(HTMLElement|Window|String)}  container    AOS container
+ * @return {(HTMLElement|Window|null)}
  */
-export default container => {
-  if (container instanceof Element || container == window) return container;
+export const resolveContainer = container => {
+  if (container instanceof Element || container === window) return container;
   if (typeof container === 'string') {
     const queryResult = document.querySelector(container);
     if (queryResult) return queryResult;
   }
-  throw `[AOS] Defined property 'container' is not valid`;
+  return null;
+};
+
+/**
+ * @param  {(HTMLElement|Window)}  container    AOS container
+ * @return {int}
+ */
+export const getElementHeight = container => {
+  return container === window ? container.innerHeight : container.clientHeight;
+};
+
+/**
+ * @param  {(HTMLElement|Window)}  container    AOS container
+ * @return {int}
+ */
+export const getElementOffset = container => {
+  return container === window ? container.pageYOffset : container.scrollTop;
 };

--- a/src/js/helpers/container.js
+++ b/src/js/helpers/container.js
@@ -1,0 +1,11 @@
+/**
+ * Return provided container if valid, otherwise throw an error
+ */
+export default container => {
+  if (container instanceof Element || container == window) return container;
+  if (typeof container === 'string') {
+    const queryResult = document.querySelector(container);
+    if (queryResult) return queryResult;
+  }
+  throw `[AOS] Defined property 'container' is not valid`;
+};

--- a/src/js/helpers/handleScroll.js
+++ b/src/js/helpers/handleScroll.js
@@ -78,9 +78,12 @@ const applyClasses = (el, top) => {
  * Scroll logic - add or remove 'aos-animate' class on scroll
  *
  * @param  {array} $elements         array of elements nodes
+ * @param  {node}  container         container
  * @return {void}
  */
-const handleScroll = $elements =>
-  $elements.forEach((el, i) => applyClasses(el, window.pageYOffset));
+const handleScroll = ($elements, container) => {
+  let top = container == window ? container.pageYOffset : container.scrollTop;
+  $elements.forEach((el, i) => applyClasses(el, top));
+};
 
 export default handleScroll;

--- a/src/js/helpers/handleScroll.js
+++ b/src/js/helpers/handleScroll.js
@@ -1,4 +1,5 @@
 import detect from './detector';
+import { getElementOffset } from './container';
 
 /**
  * Adds multiple classes on node
@@ -82,9 +83,7 @@ const applyClasses = (el, top) => {
  * @return {void}
  */
 const handleScroll = ($elements, container) => {
-  // Get the number of pixels scrolled inside the container (y-axis)
-  const top =
-    container === window ? container.pageYOffset : container.scrollTop;
+  const top = getElementOffset(container);
   $elements.forEach((el, i) => applyClasses(el, top));
 };
 

--- a/src/js/helpers/handleScroll.js
+++ b/src/js/helpers/handleScroll.js
@@ -77,12 +77,14 @@ const applyClasses = (el, top) => {
 /**
  * Scroll logic - add or remove 'aos-animate' class on scroll
  *
- * @param  {array} $elements         array of elements nodes
- * @param  {node}  container         container
+ * @param  {array}                  $elements         array of elements nodes
+ * @param  {(HTMLElement|Window)}   container         AOS container
  * @return {void}
  */
 const handleScroll = ($elements, container) => {
-  let top = container == window ? container.pageYOffset : container.scrollTop;
+  // Get the number of pixels scrolled inside the container (y-axis)
+  const top =
+    container === window ? container.pageYOffset : container.scrollTop;
   $elements.forEach((el, i) => applyClasses(el, top));
 };
 

--- a/src/js/helpers/offsetCalculator.js
+++ b/src/js/helpers/offsetCalculator.js
@@ -10,18 +10,15 @@
 
 import getOffset from './../libs/offset';
 import getInlineOption from './getInlineOption';
-import validContainer from './container';
+import { getElementHeight, getElementOffset } from './container';
 
 export const getPositionIn = (
   el,
+  container,
   defaultOffset,
-  defaultAnchorPlacement,
-  container
+  defaultAnchorPlacement
 ) => {
-  const windowHeight =
-    container === window
-      ? validContainer(container).innerHeight
-      : validContainer(container).clientHeight;
+  const containerHeight = getElementHeight(container);
   const anchor = getInlineOption(el, 'anchor');
   const inlineAnchorPlacement = getInlineOption(el, 'anchor-placement');
   const additionalOffset = Number(
@@ -30,11 +27,13 @@ export const getPositionIn = (
   const anchorPlacement = inlineAnchorPlacement || defaultAnchorPlacement;
   let finalEl = el;
 
-  if (anchor && document.querySelectorAll(anchor)) {
-    finalEl = document.querySelectorAll(anchor)[0];
+  if (anchor && container === window && document.querySelector(anchor)) {
+    finalEl = document.querySelector(anchor);
+  } else if (anchor && container.querySelector(anchor)) {
+    finalEl = container.querySelector(anchor);
   }
 
-  let triggerPoint = getOffset(finalEl).top - windowHeight;
+  let triggerPoint = getOffset(finalEl, container).top - containerHeight;
 
   switch (anchorPlacement) {
     case 'top-bottom':
@@ -47,38 +46,40 @@ export const getPositionIn = (
       triggerPoint += finalEl.offsetHeight;
       break;
     case 'top-center':
-      triggerPoint += windowHeight / 2;
+      triggerPoint += containerHeight / 2;
       break;
     case 'center-center':
-      triggerPoint += windowHeight / 2 + finalEl.offsetHeight / 2;
+      triggerPoint += containerHeight / 2 + finalEl.offsetHeight / 2;
       break;
     case 'bottom-center':
-      triggerPoint += windowHeight / 2 + finalEl.offsetHeight;
+      triggerPoint += containerHeight / 2 + finalEl.offsetHeight;
       break;
     case 'top-top':
-      triggerPoint += windowHeight;
+      triggerPoint += containerHeight;
       break;
     case 'bottom-top':
-      triggerPoint += windowHeight + finalEl.offsetHeight;
+      triggerPoint += containerHeight + finalEl.offsetHeight;
       break;
     case 'center-top':
-      triggerPoint += windowHeight + finalEl.offsetHeight / 2;
+      triggerPoint += containerHeight + finalEl.offsetHeight / 2;
       break;
   }
 
   return triggerPoint + additionalOffset;
 };
 
-export const getPositionOut = (el, defaultOffset) => {
+export const getPositionOut = (el, container, defaultOffset) => {
   const anchor = getInlineOption(el, 'anchor');
   const additionalOffset = getInlineOption(el, 'offset', defaultOffset);
   let finalEl = el;
 
-  if (anchor && document.querySelectorAll(anchor)) {
-    finalEl = document.querySelectorAll(anchor)[0];
+  if (anchor && container === window && document.querySelector(anchor)) {
+    finalEl = document.querySelector(anchor);
+  } else if (anchor && container.querySelector(anchor)) {
+    finalEl = container.querySelector(anchor);
   }
 
-  const elementOffsetTop = getOffset(finalEl).top;
+  const elementOffsetTop = getOffset(finalEl, container).top;
 
   return elementOffsetTop + finalEl.offsetHeight - additionalOffset;
 };

--- a/src/js/helpers/offsetCalculator.js
+++ b/src/js/helpers/offsetCalculator.js
@@ -10,9 +10,18 @@
 
 import getOffset from './../libs/offset';
 import getInlineOption from './getInlineOption';
+import validContainer from './container';
 
-export const getPositionIn = (el, defaultOffset, defaultAnchorPlacement) => {
-  const windowHeight = window.innerHeight;
+export const getPositionIn = (
+  el,
+  defaultOffset,
+  defaultAnchorPlacement,
+  container
+) => {
+  const windowHeight =
+    container === window
+      ? validContainer(container).innerHeight
+      : validContainer(container).clientHeight;
   const anchor = getInlineOption(el, 'anchor');
   const inlineAnchorPlacement = getInlineOption(el, 'anchor-placement');
   const additionalOffset = Number(
@@ -61,7 +70,6 @@ export const getPositionIn = (el, defaultOffset, defaultAnchorPlacement) => {
 };
 
 export const getPositionOut = (el, defaultOffset) => {
-  const windowHeight = window.innerHeight;
   const anchor = getInlineOption(el, 'anchor');
   const additionalOffset = getInlineOption(el, 'offset', defaultOffset);
   let finalEl = el;

--- a/src/js/helpers/prepare.js
+++ b/src/js/helpers/prepare.js
@@ -20,7 +20,12 @@ const prepare = function($elements, options) {
     }
 
     el.position = {
-      in: getPositionIn(el.node, options.offset, options.anchorPlacement),
+      in: getPositionIn(
+        el.node,
+        options.offset,
+        options.anchorPlacement,
+        options.container
+      ),
       out: mirror && getPositionOut(el.node, options.offset)
     };
 

--- a/src/js/helpers/prepare.js
+++ b/src/js/helpers/prepare.js
@@ -3,7 +3,7 @@
 import { getPositionIn, getPositionOut } from './offsetCalculator';
 import getInlineOption from './getInlineOption';
 
-const prepare = function($elements, options) {
+const prepare = function($elements, options, container) {
   $elements.forEach((el, i) => {
     const mirror = getInlineOption(el.node, 'mirror', options.mirror);
     const once = getInlineOption(el.node, 'once', options.once);
@@ -22,11 +22,11 @@ const prepare = function($elements, options) {
     el.position = {
       in: getPositionIn(
         el.node,
+        container,
         options.offset,
-        options.anchorPlacement,
-        options.container
+        options.anchorPlacement
       ),
-      out: mirror && getPositionOut(el.node, options.offset)
+      out: mirror && getPositionOut(el.node, container, options.offset)
     };
 
     el.options = {

--- a/src/js/libs/offset.js
+++ b/src/js/libs/offset.js
@@ -2,17 +2,18 @@
  * Get offset of DOM element
  * like there were no transforms applied on it
  *
- * @param  {Node} el [DOM element]
- * @return {Object} [top and left offset]
+ * @param  {Node}                   el        [DOM element]
+ * @param  {(HTMLElement|Window)}   container [AOS container]
+ * @return {Object}                           [top and left offset]
  */
-const offset = function(el) {
+const offset = function(el, container) {
   let _x = 0;
   let _y = 0;
 
   while (el && !isNaN(el.offsetLeft) && !isNaN(el.offsetTop)) {
     _x += el.offsetLeft - (el.tagName != 'BODY' ? el.scrollLeft : 0);
     _y += el.offsetTop - (el.tagName != 'BODY' ? el.scrollTop : 0);
-    el = el.offsetParent;
+    el = el.offsetParent === container ? null : el.offsetParent;
   }
 
   return {


### PR DESCRIPTION
## Related Issue
Issue: #223

## Your solution
- Added `container` to AOS options (default: window). 
- Variable `container` is pointing to `HTML Element`, or to `Window` if querySelector returns null.
- EventListener is passing `container` to `handleScroll()` as a second argument
- `handleScroll()` evaluates scroll distance by using `Element.scrollTop` or `Window.pageYOffset`


### Defining scrollable element
```js
AOS.init({
  container: ".scrollable-div"
})
```
## How Has This Been Tested?
- By running included tests

In own projects, tested on:
- Desktop: Firefox 62, Chrome 71, Edge 42
- Android: Chrome, Firefox
