### PR TITLE
fix: disable mutation observing when not supported

### DIFF
--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -11,7 +11,7 @@ import styles from './../sass/aos.scss';
 import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
 
-import observe from './libs/observer';
+import observer from './libs/observer';
 
 import detect from './helpers/detector';
 import handleScroll from './helpers/handleScroll';
@@ -119,6 +119,18 @@ const init = function init(settings) {
   }
 
   /**
+   * Disable mutation observing if not supported
+   */
+  if (!options.disableMutationObserver && !observer.isSupported()) {
+    console.info(`
+      aos: MutationObserver is not supported on this browser,
+      code mutations observing has been disabled.
+      You may have to call "refreshHard()" by yourself.
+    `);
+    options.disableMutationObserver = true;
+  }
+
+  /**
    * Set global settings on body, based on options
    * so CSS can use it
    */
@@ -164,7 +176,7 @@ const init = function init(settings) {
    * it'll refresh plugin automatically
    */
   if (!options.disableMutationObserver) {
-    observe('[data-aos]', refreshHard);
+    observer.ready('[data-aos]', refreshHard);
   }
 
   return $aosElements;

--- a/src/js/libs/observer.js
+++ b/src/js/libs/observer.js
@@ -20,12 +20,19 @@ function containsAOSNode(nodes) {
   return false;
 }
 
+function getMutationObserver() {
+  return window.MutationObserver ||
+    window.WebKitMutationObserver ||
+    window.MozMutationObserver;
+}
+
+function isSupported() {
+  return !!getMutationObserver();
+}
+
 function ready(selector, fn) {
   const doc = window.document;
-  const MutationObserver =
-  window.MutationObserver ||
-  window.WebKitMutationObserver ||
-  window.MozMutationObserver;
+  const MutationObserver = getMutationObserver();
 
   const observer = new MutationObserver(check);
   callback = fn;
@@ -51,4 +58,4 @@ function check(mutations) {
   });
 }
 
-export default ready;
+export default { isSupported, ready };


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes https://github.com/michalsnik/aos/issues/404

## Your solution
<!--- Plese describe your solution, have you encountered any issues along the way? -->

Disable mutation observing and display a message when MutationObserver is not supported by the browser.

> aos: MutationObserver is not supported on this browser,
> code mutations observing has been disabled.
> You may have to call "refreshHard()" by yourself.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `npm run build`
- linked and tested in an other project
- `npm test` (all tests passed)
- search for possible side-effects

---

**Note**

When preparing a new version, the `next` version should always be ahead of the past versions. When bugfixes are or new features are added, they should be made in priority on the `next` version, and duplicated on older versions for long-term support and quick-release purposes. Older versions should not contains features or fixes the `next` version does not have. This way, no regression will be made when releasing the `next` version.

I tried to provide the same fix for the `next` branch, but the `disableMutationObserver` is not implemented on it. This is a real problem with the development workflow of this project. I would recommend you to take a look at [the Foundation Contributing Guidelines](https://github.com/zurb/foundation-sites/blob/develop/CONTRIBUTING.md) that explains how we deal with the parallel development of several versions.