### PR TITLE
fix: wrong custom event name for specific elements targeted events

### DIFF
--- a/src/js/helpers/handleScroll.js
+++ b/src/js/helpers/handleScroll.js
@@ -46,7 +46,7 @@ const applyClasses = (el, top) => {
     fireEvent('aos:out', node);
 
     if (el.options.id) {
-      fireEvent(`aos:in:${el.options.id}`, node);
+      fireEvent(`aos:out:${el.options.id}`, node);
     }
 
     el.animated = false;


### PR DESCRIPTION
## Related Issue

No previous issue, but as it's clearly a mistake, PR was created.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Your solution
<!--- Plese describe your solution, have you encountered any issues along the way? -->
`aos:out:specific-id` custom events created for specific elements events handling via `data-aos-id` attributes were wrongly named as `aos:in:specific-id` instead of `aos:out:specific-id`, just renamed it accordingly.