### PR TITLE
Includes dependencies in ESM build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,13 +35,14 @@ export default [
   },
   {
     input,
-    external: Object.keys(pkg.dependencies),
     output: [
       { file: pkg.main, format: 'cjs' },
       { file: pkg.module, format: 'es' }
     ],
     plugins: [
       transformStyles,
+      resolve(),
+      commonjs(),
       babel({
         exclude: ['node_modules/**']
       })


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#422 

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Removed `external` option for Rollup and added `resolve` and `commonjs` plugins.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Used the new ESM bundle on the browser as a module, and AOS is working. As it does not change any source code, it should work fine as is.

```html
<script type="module">
  import AOS from "./node_modules/aos/dist/aos.esm.js";
  AOS.init({});
</script>
```