### PR TITLE
hide() now fires aos:out:customEvent instead of aos:in:customEvent

### DIFF
--- a/src/js/helpers/handleScroll.js
+++ b/src/js/helpers/handleScroll.js
@@ -46,7 +46,7 @@ const applyClasses = (el, top) => {
     fireEvent('aos:out', node);
 
     if (el.options.id) {
-      fireEvent(`aos:in:${el.options.id}`, node);
+      fireEvent(`aos:out:${el.options.id}`, node);
     }
 
     el.animated = false;


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/michalsnik/aos/issues/473

## Your solution
<!--- Plese describe your solution, have you encountered any issues along the way? -->
fixed a simple typo

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fired some custom events to test

## Screenshots (if relevant):
