### PR TITLE
fix window scroll handler leaks

### DIFF
--- a/src/js/aos.js
+++ b/src/js/aos.js
@@ -48,6 +48,8 @@ let options = {
 // http://browserhacks.com/#hack-e71d8692f65334173fee715c222cb805
 const isBrowserNotSupported = () => document.all && !window.atob;
 
+// current window scroll handler
+let currentScrollHandler
 const initializeScroll = function initializeScroll() {
   // Extend elements objects in $aosElements with their positions
   $aosElements = prepare($aosElements, options);
@@ -57,12 +59,13 @@ const initializeScroll = function initializeScroll() {
   /**
    * Handle scroll event to animate elements on scroll
    */
-  window.addEventListener(
-    'scroll',
-    throttle(() => {
-      handleScroll($aosElements, options.once);
-    }, options.throttleDelay)
-  );
+  if (currentScrollHandler) {
+    window.removeEventListener('scroll', currentScrollHandler)
+  }
+  currentScrollHandler = throttle(() => {
+    handleScroll($aosElements, options.once);
+  }, options.throttleDelay)
+  window.addEventListener('scroll', currentScrollHandler)
 
   return $aosElements;
 };


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
The `window`'s `scroll` handler is not removed when a new `scroll` handler is to be installed.

This does not only leak handlers but also causes accumulated `scroll` handlers to be executed every time the `scroll` event is fired.

## Your solution
<!--- Plese describe your solution, have you encountered any issues along the way? -->
remove current `scroll` handler when a new `scroll` handler is to be installed

